### PR TITLE
Update bench.js

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -1,7 +1,8 @@
-var sys = require('sys');
+var util = require('util');
 var node_xml = require("node-xml");
 var libxml = require("libxmljs");
-var expat = require('./lib/node-expat');
+var expat = require('node-expat');
+var sax = require('sax');
 
 function NodeXmlParser() {
     var parser = new node_xml.SaxParser(function(cb) { });
@@ -15,6 +16,12 @@ function LibXmlJsParser() {
 	parser.push(s, false);
     };
 }
+function SaxParser() {
+    var parser = sax.parser();
+	this.parse = function(s) {
+	parser.write(s).close();
+	}
+}
 function ExpatParser() {
     var parser = new expat.Parser();
     this.parse = function(s) {
@@ -24,6 +31,7 @@ function ExpatParser() {
 
 //var p = new NodeXmlParser();
 //var p = new LibXmlJsParser();
+//var p = new SaxParser();
 var p = new ExpatParser();
 p.parse("<r>");
 var nEl = 0;
@@ -34,7 +42,19 @@ function d() {
 }
 d();
 
+var its =[];
 setInterval(function() {
-    sys.puts(nEl + " el/s");
+    util.puts(nEl + " el/s");
+	its.push(nEl);
     nEl = 0;
 }, 1000);
+
+process.on('SIGINT', function () {
+	var average = 0;
+	its.forEach(function (v){
+		average += v;
+	});
+	average /= its.length;
+	util.puts("Average: " + average + " el/s");
+	process.exit(0);
+});


### PR DESCRIPTION
- added 'sax' parser to benchmark;
- added average el/s calculation on process exit;
- require 'sys' replaced with 'util' as proposed in the new versions of Nodejs.
