### PR TITLE
use NAN for Node 0.8->0.11+ compatibility

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,9 @@
     {
       'target_name': 'node_expat',
       'sources': [ 'node-expat.cc' ],
+      'include_dirs': [
+        '<!(node -e \'require("nan")\')'
+      ],
       'dependencies': [
         'deps/libexpat/libexpat.gyp:expat'
       ]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 ,"description": "NodeJS binding for fast XML parsing."
 ,"keywords": ["xml","sax","expat","libexpat","parse","parsing"]
 ,"scripts" : { "test": "vows --spec ./test.js" }
-,"dependencies": {}
+,"dependencies": {"nan": "~0.6.0"}
 ,"devDependencies": {"vows": ">=0.5.12"}
 ,"repository": { "type": "git"
   , "path": "git://github.com/astro/node-expat.git"


### PR DESCRIPTION
Node 0.11 and onwards uses the new V8 which has huge breaking API changes. NAN is designed to make it easy to support V8 and Node across versions 0.8 to 0.11 and onwards without the need for branching macros. NAN is keeping up-to-date as newer versions of Node 0.11 are released and new breaking changes come upstream from V8.

This PR adds NAN support for compiling against the latest Node 0.11; tests all pass. Would be good to get this in npm before the impending 0.12 release.

Let me know if you have any questions.
