### PR TITLE
fix quoting for Windows compile

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,7 @@
       'target_name': 'node_expat',
       'sources': [ 'node-expat.cc' ],
       'include_dirs': [
-        '<!(node -e \'require("nan")\')'
+        '<!(node -e "require(\'nan\')")'
       ],
       'dependencies': [
         'deps/libexpat/libexpat.gyp:expat'


### PR DESCRIPTION
fixes #78

sorry about this, I should have remembered that Windows is a troll about quoting, compiles properly on Windows now.
