### PR TITLE
Use bindings lib to locate addon

### DIFF
--- a/lib/node-expat.js
+++ b/lib/node-expat.js
@@ -1,7 +1,7 @@
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 // Only support nodejs v0.6 and on so no need to look for older module location
-var expat = require('../build/Release/node_expat.node');
+var expat = require('bindings')('node_expat');
 var Stream = require('stream').Stream;
 
 var Parser = function(encoding) {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "vows --spec ./test.js"
   },
   "dependencies": {
+    "bindings": "~1.2.1",
     "nan": "~1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Just noticed it didn't work with my debug version of Node, this is because the binding file can be in either _Release_ or _Debug_, so just use the bindings lib to locate it safely.
