### PR TITLE
Draft: Make the module initialization context-aware

### DIFF
--- a/node-expat.cc
+++ b/node-expat.cc
@@ -494,7 +494,9 @@ extern "C" {
   {
     Parser::Initialize(target);
   }
-  //Changed the name cause I couldn't load the module with - in their names
-  NODE_MODULE(node_expat, InitAll);
+  // Make init context aware
+  NODE_MODULE_INIT() {
+    InitAll(exports);
+  }
 };
 


### PR DESCRIPTION
When we use this module in a worker thread we get a `Uncaught Error: Module did not self-register` when we require it.

The reason is, that the module registration is not context aware. When we change the initialization as described in 
https://github.com/nodejs/node/blob/main/doc/api/addons.md#context-aware-addons it works for us. 

Changing this could be a problem, if the module has a global state, but I could not find any, so I think it should work.